### PR TITLE
Remove total tx load from benchmark params

### DIFF
--- a/benchmark/aws/remote.py
+++ b/benchmark/aws/remote.py
@@ -198,6 +198,10 @@ class Bench:
             )
             self._background_run(host, cmd, log_file)
 
+        # Wait for the nodes to synchronize
+        Print.info('Waiting for the nodes to synchronize...')
+        sleep(2 * node_parameters.timeout_delay / 1000)
+
         # Wait for all transactions to be processed.
         duration = bench_parameters.duration
         for _ in progress_bar(range(20), prefix=f'Running benchmark ({duration} sec):'):

--- a/benchmark/aws/remote.py
+++ b/benchmark/aws/remote.py
@@ -171,14 +171,12 @@ class Bench:
         # Run the clients (they will wait for the nodes to be ready).
         committee = Committee.load(PathMaker.committee_file())
         addresses = committee.front_addresses()
-        txs_share = ceil(bench_parameters.txs / committee.size())
         rate_share = ceil(bench_parameters.rate / committee.size())
         timeout = node_parameters.timeout_delay
         client_logs = [PathMaker.client_log_file(i) for i in range(len(hosts))]
         for host, addr, log_file in zip(hosts, addresses, client_logs):
             cmd = CommandMaker.run_client(
                 addr,
-                txs_share,
                 bench_parameters.size,
                 rate_share,
                 timeout,

--- a/benchmark/benchmark/commands.py
+++ b/benchmark/benchmark/commands.py
@@ -31,15 +31,14 @@ class CommandMaker:
                 f'--store {store} --parameters {parameters}')
 
     @staticmethod
-    def run_client(address, txs, size, rate, timeout, nodes=[]):
+    def run_client(address, size, rate, timeout, nodes=[]):
         assert isinstance(address, str)
-        assert isinstance(txs, int)
         assert isinstance(size, int) and size > 0
         assert isinstance(rate, int) and rate >= 0
         assert isinstance(nodes, list) 
         assert all(isinstance(x, str) for x in nodes)
         nodes = f'--nodes {" ".join(nodes)}' if nodes else ''
-        return (f'./client {address} --transactions {txs} --size {size} '
+        return (f'./client {address} --size {size} '
                 f'--rate {rate} --timeout {timeout} {nodes}')
 
     @staticmethod

--- a/benchmark/benchmark/config.py
+++ b/benchmark/benchmark/config.py
@@ -118,7 +118,6 @@ class BenchParameters:
                 raise ConfigError('Missing number of nodes')
 
             self.nodes = [int(x) for x in nodes]
-            self.txs = int(json['txs'])
             self.rate = int(json['rate'])
             self.size = int(json['size'])
             self.duration = int(json['duration'])

--- a/benchmark/benchmark/local.py
+++ b/benchmark/benchmark/local.py
@@ -42,7 +42,6 @@ class LocalBench:
         self._kill_nodes()
 
         try:
-            '''
             Print.info('Setting up testbed...')
             nodes = self.nodes[0]
 
@@ -104,7 +103,7 @@ class LocalBench:
             Print.info(f'Running benchmark ({self.duration} sec)...')
             sleep(self.duration)
             self._kill_nodes()
-            '''
+
             # Parse logs and return the parser.
             Print.info('Parsing logs...')
             return LogParser.process('./logs')

--- a/benchmark/benchmark/local.py
+++ b/benchmark/benchmark/local.py
@@ -99,6 +99,10 @@ class LocalBench:
                 )
                 self._background_run(cmd, log_file)
 
+            # Wait for the nodes to synchronize
+            Print.info('Waiting for the nodes to synchronize...')
+            sleep(2 * self.node_parameters.timeout_delay / 1000)
+
             # Wait for all transactions to be processed.
             Print.info(f'Running benchmark ({self.duration} sec)...')
             sleep(self.duration)

--- a/benchmark/benchmark/local.py
+++ b/benchmark/benchmark/local.py
@@ -42,6 +42,7 @@ class LocalBench:
         self._kill_nodes()
 
         try:
+            '''
             Print.info('Setting up testbed...')
             nodes = self.nodes[0]
 
@@ -74,14 +75,12 @@ class LocalBench:
 
             # Run the clients (they will wait for the nodes to be ready).
             addresses = committee.front_addresses()
-            txs_share = ceil(self.txs / nodes)
             rate_share = ceil(self.rate / nodes)
             timeout = self.node_parameters.timeout_delay
             client_logs = [PathMaker.client_log_file(i) for i in range(nodes)]
             for addr, log_file in zip(addresses, client_logs):
                 cmd = CommandMaker.run_client(
                     addr,
-                    txs_share,
                     self.size,
                     rate_share,
                     timeout
@@ -105,7 +104,7 @@ class LocalBench:
             Print.info(f'Running benchmark ({self.duration} sec)...')
             sleep(self.duration)
             self._kill_nodes()
-
+            '''
             # Parse logs and return the parser.
             Print.info('Parsing logs...')
             return LogParser.process('./logs')

--- a/benchmark/benchmark/logs.py
+++ b/benchmark/benchmark/logs.py
@@ -53,7 +53,7 @@ class LogParser:
 
         # Check whether the nodes timed out.
         # Note that nodes are expected to time out once at the beginning.
-        if self.timeouts > 1:  
+        if self.timeouts > 1:
             Print.warn(f'Nodes timed out {self.timeouts:,} time(s)')
 
     def _parse_clients(self, log):
@@ -130,10 +130,10 @@ class LogParser:
             start_times.sort()
 
             end_times = []
-            for digest, occurrence in samples.items():
+            for digest, occurrences in samples.items():
                 tmp = self.commits[digest]
-                end_times += [tmp] * occurrence
-            
+                end_times += [tmp] * occurrences
+
             latency += [x - y for x, y in zip(end_times, start_times)]
         return mean(latency) if latency else 0
 

--- a/benchmark/benchmark/logs.py
+++ b/benchmark/benchmark/logs.py
@@ -59,9 +59,7 @@ class LogParser:
 
     def _parse_clients(self, log):
         if search(r'Error', log) is not None:
-            # TODO: Clients may be killed after nodes...
-            #raise ParseError('Client(s) panicked')
-            pass
+            raise ParseError('Client(s) panicked')
 
         size = int(search(r'Transactions size: (\d+)', log).group(1))
         rate = int(search(r'Transactions rate: (\d+)', log).group(1))

--- a/benchmark/benchmark/logs.py
+++ b/benchmark/benchmark/logs.py
@@ -30,9 +30,9 @@ class LogParser:
             with Pool() as p:
                 results = p.map(self._parse_clients, clients)
         except (ValueError, IndexError) as e:
-            raise ParseError(f'Failed to parse client log: {e}')
-        self.txs, self.size, self.rate, self.start, self.end, misses, \
-            self.sent_samples = zip(*results)
+            raise ParseError(f'Failed to parse client logs: {e}')
+        self.size, self.rate, self.start, misses, self.sent_samples \
+            = zip(*results)
         self.misses = sum(misses)
 
         # Parse the nodes logs.
@@ -40,64 +40,51 @@ class LogParser:
             with Pool() as p:
                 results = p.map(self._parse_nodes, nodes)
         except (ValueError, IndexError) as e:
-            raise ParseError(f'Failed to parse node log: {e}')
-        self.payload, proposals, commits, samples, timeouts = zip(*results)
+            raise ParseError(f'Failed to parse node logs: {e}')
+        self.payload, proposals, commits, sizes, samples, timeouts \
+            = zip(*results)
         self.proposals = {k: v for x in proposals for k, v in x.items()}
         self.commits = {k: v for x in commits for k, v in x.items()}
+        self.sizes = {k: v for x in sizes for k, v in x.items()}
         self.samples = {k: v for x in samples for k, v in x.items()}
         self.timeouts = max(timeouts)
 
-        # Check whether clients missed their target rate or if the nodes timed out.
+        # Check whether clients missed their target rate.
         if self.misses != 0:
             Print.warn(
                 f'Clients missed their target rate {self.misses:,} time(s)'
             )
 
-        if self.timeouts > 1:  # It is expected to time out once at the beginning.
+        # Check whether the nodes timed out.
+        # Note that nodes are expected to time out once at the beginning.
+        if self.timeouts > 1:  
             Print.warn(f'Nodes timed out {self.timeouts:,} time(s)')
 
-        # Ensure that all (non-empty) blocks and sample transactions are committed.
-        if len(self.proposals) != len(self.commits):
-            raise ParseError('Nodes did not commit all non-empty block(s)')
-
-        if any(not x in self.commits for x in self.samples.keys()):
-            raise ParseError('Nodes did not commit all sample tx(s)')
-
     def _verify(self, clients, nodes):
-        # Ensure all clients managed to submit their share of txs.
-        status = [search(r'Finished', x) for x in clients]
-        if sum(x is not None for x in status) != len(clients):
-            raise ParseError('Client(s) failed to send all their txs')
-
         with Pool() as p:
+            # Ensure none of the clients panicked.
+            status = p.starmap(search, zip(repeat(r'Error'), clients))
+            if any(x is not None for x in status):
+                raise ParseError('Client(s) panicked')
+
             # Ensure none of the nodes panicked.
             status = p.starmap(search, zip(repeat(r'panic'), nodes))
             if any(x is not None for x in status):
                 raise ParseError('Node(s) panicked')
 
-            # Ensure no transactions have been dropped.
-            status = p.starmap(search, zip(
-                repeat(r'dropping transaction'), nodes)
-            )
-            if any(x is not None for x in status):
-                raise ParseError('Transactions dropped (mempool buffer full)')
-
     def _parse_clients(self, log):
-        txs = int(search(r'Number of transactions: (\d+)', log).group(1))
         size = int(search(r'Transactions size: (\d+)', log).group(1))
         rate = int(search(r'Transactions rate: (\d+)', log).group(1))
 
         tmp = search(r'\[(.*Z) .* Start ', log).group(1)
         start = self._to_posix(tmp)
-        tmp = search(r'\[(.*Z) .* Finished', log).group(1)
-        end = self._to_posix(tmp)
 
         misses = len(findall(r'rate too high', log))
 
         tmp = findall(r'\[(.*Z) .* sample transaction', log)
         samples = [self._to_posix(x) for x in tmp]
 
-        return txs, size, rate, start, end, misses, samples
+        return size, rate, start, misses, samples
 
     def _parse_nodes(self, log):
         payload = int(search(r'Max payload size: (\d+)', log).group(1))
@@ -108,13 +95,16 @@ class LogParser:
         tmp = findall(r'\[(.*Z) .* Committed B\d+\(([^ ]+)\)', log)
         commits = {d: self._to_posix(t) for t, d in tmp if d in proposals}
 
+        tmp = findall(r'Payload ([^ ]+) contains (\d+) B', log)
+        sizes = {d: int(s) for d, s in tmp if d in commits}
+
         tmp = findall(r'Payload ([^ ]+) contains (\d+) sample', log)
         samples = {d: int(s) for d, s in tmp}
 
-        tmp = findall(r'.* Timeout reached', log)
+        tmp = findall(r'.* Timeout', log)
         timeouts = len(tmp)
 
-        return payload, proposals, commits, samples, timeouts
+        return payload, proposals, commits, sizes, samples, timeouts
 
     def _to_posix(self, string):
         x = datetime.fromisoformat(string.replace('Z', '+00:00'))
@@ -125,8 +115,9 @@ class LogParser:
             return 0, 0, 0
         start, end = min(self.proposals.values()), max(self.commits.values())
         duration = end - start
-        tps = sum(self.txs) / duration
-        bps = tps * self.size[0]
+        bytes = sum(self.sizes.values())
+        bps = bytes / duration
+        tps = bps / self.size[0]
         return tps, bps, duration
 
     def _consensus_latency(self):
@@ -140,8 +131,9 @@ class LogParser:
             return 0, 0, 0
         start, end = min(self.start), max(self.commits.values())
         duration = end - start
-        tps = sum(self.txs) / duration
-        bps = tps * self.size[0]
+        bytes = sum(self.sizes.values())
+        bps = bytes / duration
+        tps = bps / self.size[0]
         return tps, bps, duration
 
     def _end_to_end_latency(self):
@@ -167,7 +159,6 @@ class LogParser:
             ' RESULTS:\n'
             '-----------------------------------------\n'
             f' Committee size: {self.committee_size} nodes\n'
-            f' Number of transactions: {sum(self.txs):,} txs\n'
             f' Max payload size: {self.payload[0]:,} B \n'
             f' Transaction size: {self.size[0]:,} B \n'
             f' Transaction rate: {sum(self.rate):,} tx/s\n'

--- a/benchmark/fabfile.py
+++ b/benchmark/fabfile.py
@@ -88,9 +88,8 @@ def install(ctx):
 def remote(ctx):
     bench_params = {
         'nodes': [4],
-        'txs': 2_000_000,
         'size': 512,
-        'rate': 10_000,
+        'rate': 7_000,
         'duration': 360,
         'runs': 1,
     }
@@ -136,3 +135,9 @@ def plot(ctx):
         ploter.plot_latency('Committee size', ploter.txs)
     except PlotError as e:
         Print.error(BenchError('Failed to plot performance', e))
+
+@task
+def test(ctx):
+    from benchmark.logs import LogParser
+    ret = LogParser.process('./logs').result()
+    print(ret)

--- a/benchmark/fabfile.py
+++ b/benchmark/fabfile.py
@@ -95,12 +95,12 @@ def remote(ctx):
     }
     node_params = {
         'consensus': {
-            'timeout_delay': 20_000,
+            'timeout_delay': 100_000,
             'sync_retry_delay': 10_000
         },
         'mempool': {
             'queue_capacity': 100_000_000,
-            'max_payload_size': 2_000_000
+            'max_payload_size': 2000_000
         }
     }
     try:

--- a/benchmark/fabfile.py
+++ b/benchmark/fabfile.py
@@ -2,7 +2,7 @@ from fabric import task
 from glob import glob
 
 from benchmark.local import LocalBench
-from benchmark.logs import ParseError, LogAggregator
+from benchmark.logs import ParseError, LogParser, LogAggregator
 from benchmark.utils import Print
 from benchmark.plot import Ploter, PlotError
 from aws.instance import InstanceManager
@@ -89,7 +89,7 @@ def remote(ctx):
     bench_params = {
         'nodes': [4],
         'size': 512,
-        'rate': 7_000,
+        'rate': 10_000,
         'duration': 360,
         'runs': 1,
     }
@@ -118,6 +118,14 @@ def kill(ctx):
 
 
 @task
+def logs(ctx):
+    try:
+        print(LogParser.process('./logs').result())
+    except ParseError as e:
+        Print.error(BenchError('Failed to parse logs', e))
+
+
+@task
 def aggregate(ctx):
     files = glob('benchmark.*.txt')
     try:
@@ -135,9 +143,3 @@ def plot(ctx):
         ploter.plot_latency('Committee size', ploter.txs)
     except PlotError as e:
         Print.error(BenchError('Failed to plot performance', e))
-
-@task
-def test(ctx):
-    from benchmark.logs import LogParser
-    ret = LogParser.process('./logs').result()
-    print(ret)

--- a/benchmark/fabfile.py
+++ b/benchmark/fabfile.py
@@ -17,7 +17,7 @@ def local(ct):
         'nodes': 4,
         'size': 512,
         'rate': 1000,
-        'duration': 30,
+        'duration': 20,
     }
     node_params = {
         'consensus': {
@@ -89,18 +89,18 @@ def remote(ctx):
     bench_params = {
         'nodes': [4],
         'size': 512,
-        'rate': 10_000,
-        'duration': 360,
+        'rate': 9_000,
+        'duration': 300,
         'runs': 1,
     }
     node_params = {
         'consensus': {
-            'timeout_delay': 100_000,
+            'timeout_delay': 30_000,
             'sync_retry_delay': 10_000
         },
         'mempool': {
             'queue_capacity': 100_000_000,
-            'max_payload_size': 2000_000
+            'max_payload_size': 1_000_000
         }
     }
     try:

--- a/benchmark/fabfile.py
+++ b/benchmark/fabfile.py
@@ -100,7 +100,7 @@ def remote(ctx):
         },
         'mempool': {
             'queue_capacity': 100_000_000,
-            'max_payload_size': 2_000_000
+            'max_payload_size': 100_000
         }
     }
     try:

--- a/benchmark/fabfile.py
+++ b/benchmark/fabfile.py
@@ -15,14 +15,13 @@ from aws.remote import Bench, BenchError
 def local(ct):
     bench_params = {
         'nodes': 4,
-        'txs': 10_000,
         'size': 512,
-        'rate': 1_000,
+        'rate': 1000,
         'duration': 30,
     }
     node_params = {
         'consensus': {
-            'timeout_delay': 5000,
+            'timeout_delay': 2000,
             'sync_retry_delay': 10_000
         },
         'mempool': {
@@ -31,7 +30,7 @@ def local(ct):
         }
     }
     try:
-        ret = LocalBench(bench_params, node_params).run(debug=True).result()
+        ret = LocalBench(bench_params, node_params).run(debug=False).result()
         print(ret)
     except BenchError as e:
         Print.error(e)

--- a/benchmark/fabfile.py
+++ b/benchmark/fabfile.py
@@ -100,7 +100,7 @@ def remote(ctx):
         },
         'mempool': {
             'queue_capacity': 100_000_000,
-            'max_payload_size': 100_000
+            'max_payload_size': 2_000_000
         }
     }
     try:

--- a/mempool/src/core.rs
+++ b/mempool/src/core.rs
@@ -101,6 +101,9 @@ impl Core {
         let bytes = digest.to_vec();
 
         #[cfg(feature = "benchmark")]
+        info!("Payload {} contains {} B", base64::encode(&bytes), payload.size());
+
+        #[cfg(feature = "benchmark")]
         if payload.sample_txs > 0 {
             info!(
                 "Payload {} contains {} sample tx(s)",

--- a/node/src/client.rs
+++ b/node/src/client.rs
@@ -18,7 +18,6 @@ async fn main() -> Result<()> {
         .about("Benchmark client for HotStuff nodes.")
         .args_from_usage("<ADDR> 'The network address of the node where to send txs'")
         .args_from_usage("--timeout=<INT> 'The nodes timeout value'")
-        .args_from_usage("--transactions=<INT> 'The number of transactions for the benchmark'")
         .args_from_usage("--size=<INT> 'The size of each transaction in bytes'")
         .args_from_usage("--rate=<INT> 'The rate (txs/s) at which to send the transactions'")
         .args_from_usage("--nodes=[ADDR]... 'Network addresses that must be reachable before starting the benchmark.'")
@@ -34,11 +33,6 @@ async fn main() -> Result<()> {
         .unwrap()
         .parse::<SocketAddr>()
         .context("Invalid socket address format")?;
-    let transactions = matches
-        .value_of("transactions")
-        .unwrap()
-        .parse::<usize>()
-        .context("The number of transactions must be a non-negative integer")?;
     let size = matches
         .value_of("size")
         .unwrap()
@@ -47,7 +41,7 @@ async fn main() -> Result<()> {
     let rate = matches
         .value_of("rate")
         .unwrap()
-        .parse::<usize>()
+        .parse::<u64>()
         .context("The rate of transactions must be a non-negative integer")?;
     let timeout = matches
         .value_of("timeout")
@@ -63,12 +57,10 @@ async fn main() -> Result<()> {
         .context("Invalid socket address format")?;
 
     info!("Node address: {}", target);
-    info!("Number of transactions: {}", transactions);
     info!("Transactions size: {} B", size);
     info!("Transactions rate: {} tx/s", rate);
     let client = Client {
         target,
-        transactions,
         size,
         rate,
         timeout,
@@ -84,17 +76,16 @@ async fn main() -> Result<()> {
 
 struct Client {
     target: SocketAddr,
-    transactions: usize,
     size: usize,
-    rate: usize,
+    rate: u64,
     timeout: u64,
     nodes: Vec<SocketAddr>,
 }
 
 impl Client {
     pub async fn send(&self) -> Result<()> {
-        const PRECISION: usize = 20; // Sample precision.
-        const BURST_DURATION: usize = 1000 / PRECISION;
+        const PRECISION: u64 = 20; // Sample precision.
+        const BURST_DURATION: u64 = 1000 / PRECISION;
 
         // The transaction size must be at least 16 bytes to ensure all txs are different.
         if self.size < 16 {
@@ -103,44 +94,36 @@ impl Client {
             ));
         }
 
-        // Adapt for the case where the transaction rate is zero.
-        let (batches, burst) = match self.rate {
-            0 => (1, self.transactions),
-            _ => (
-                PRECISION * self.transactions / self.rate + 1,
-                self.rate / PRECISION,
-            ),
-        };
-
         // Connect to the mempool.
         let stream = TcpStream::connect(self.target)
             .await
             .context(format!("failed to connect to {}", self.target))?;
 
         // Submit all transactions.
+        let burst = self.rate / PRECISION;
+        let mut counter = 0;
         let mut transport = Framed::new(stream, LengthDelimitedCodec::new());
-        let interval = interval(Duration::from_millis(BURST_DURATION as u64));
+        let interval = interval(Duration::from_millis(BURST_DURATION));
         tokio::pin!(interval);
         info!("Start sending transactions");
-        for x in 0..batches {
+        loop {
             interval.as_mut().tick().await;
             let now = Instant::now();
-            self.send_burst(&mut transport, burst, x as u64).await?;
-            if self.rate != 0 && now.elapsed().as_millis() > BURST_DURATION as u128 {
+            self.send_burst(&mut transport, burst, counter).await?;
+            if now.elapsed().as_millis() > BURST_DURATION as u128 {
                 warn!("Transaction rate too high for this client");
             }
-            if x % PRECISION == 0 {
+            if counter % PRECISION == 0 {
                 self.send_sample_transaction(&mut transport).await?;
             }
+            counter += 1;
         }
-        info!("Finished sending transactions");
-        Ok(())
     }
 
     async fn send_burst(
         &self,
         transport: &mut Framed<TcpStream, LengthDelimitedCodec>,
-        load: usize,
+        load: u64,
         nonce: u64,
     ) -> Result<()> {
         for x in 0..load {

--- a/node/src/client.rs
+++ b/node/src/client.rs
@@ -109,12 +109,16 @@ impl Client {
         loop {
             interval.as_mut().tick().await;
             let now = Instant::now();
-            self.send_burst(&mut transport, burst, counter).await?;
+            if let Err(e) = self.send_burst(&mut transport, burst, counter).await {
+                warn!("{}", e);
+            }
             if now.elapsed().as_millis() > BURST_DURATION as u128 {
                 warn!("Transaction rate too high for this client");
             }
             if counter % PRECISION == 0 {
-                self.send_sample_transaction(&mut transport).await?;
+                if let Err(e) = self.send_sample_transaction(&mut transport).await {
+                    warn!("{}", e);
+                }
             }
             counter += 1;
         }

--- a/node/src/client.rs
+++ b/node/src/client.rs
@@ -110,18 +110,21 @@ impl Client {
             interval.as_mut().tick().await;
             let now = Instant::now();
             if let Err(e) = self.send_burst(&mut transport, burst, counter).await {
-                warn!("{}", e);
+                warn!("{:?}", e);
+                break;
             }
             if now.elapsed().as_millis() > BURST_DURATION as u128 {
                 warn!("Transaction rate too high for this client");
             }
             if counter % PRECISION == 0 {
                 if let Err(e) = self.send_sample_transaction(&mut transport).await {
-                    warn!("{}", e);
+                    warn!("{:?}", e);
+                    break;
                 }
             }
             counter += 1;
         }
+        Ok(())
     }
 
     async fn send_burst(


### PR DESCRIPTION
We currently need to specify the total transaction load and bench time upon running any benchmark. This PR removes the transaction load from the parameters and makes the bench run as long as specified. The benchmark client continuously sending transactions until it is killed.