### PR TITLE
Small fixes for VPCs

### DIFF
--- a/benchmark/aws/instance.py
+++ b/benchmark/aws/instance.py
@@ -119,7 +119,12 @@ class InstanceManager:
             FromPort=self.settings.front_port,
             ToPort=self.settings.front_port
         )
-
+        sec_group.authorize_ingress(
+            CidrIp='0.0.0.0/0',
+            IpProtocol='icmp',
+            FromPort=-1,
+            ToPort=-1
+        )
         return subnet.id, sec_group.id
 
     def _get_vpc_info(self, client):

--- a/benchmark/aws/settings.py
+++ b/benchmark/aws/settings.py
@@ -7,7 +7,7 @@ class SettingsError(Exception):
 
 class Settings:
     def __init__(self, key_name, key_path, consensus_port, mempool_port, front_port, repo_name,
-                 repo_url, branch, instance_type, aws_regions):
+                 repo_url, branch, instance_type, aws_regions, vpc_cidr, subnet_cidr):
         regions = aws_regions if isinstance(
             aws_regions, list) else [aws_regions]
         inputs_str = [
@@ -35,6 +35,9 @@ class Settings:
         self.instance_type = instance_type
         self.aws_regions = regions
 
+        self.vpc_cidr = vpc_cidr
+        self.subnet_cidr = subnet_cidr
+
     @classmethod
     def load(cls, filename):
         try:
@@ -52,6 +55,8 @@ class Settings:
                 data['repo']['branch'],
                 data['instances']['type'],
                 data['instances']['regions'],
+                data['vpc']['vpc_cidr'],
+                data['vpc']['subnet_cidr']
             )
         except (OSError, JSONDecodeError) as e:
             raise SettingsError(str(e))

--- a/benchmark/settings.json
+++ b/benchmark/settings.json
@@ -16,5 +16,9 @@
     "instances": {
         "type": "m5d.8xlarge",
         "regions": ["us-east-1", "eu-north-1", "ap-southeast-2", "us-west-1", "ap-northeast-1"]
+    },
+    "vpc": {
+        "vpc_cidr": "192.168.0.0/16",
+        "subnet_cidr": "192.168.1.0/24"
     }
 }


### PR DESCRIPTION
This PR fixes some small issues with VPC creation: 
- One of the nodes deployed was associated to the default VPC security group (any any allow) instead of the dedicated ones with rules. 
- First host ( -0) was associated to the correct subnet, others were wrongly associated to to other subnets in the VPC if present
- I've also made the VPC CIDR configurable and allowed ICMP in the security group for troubleshooting. 