### PR TITLE
Check TC

### DIFF
--- a/consensus/src/core.rs
+++ b/consensus/src/core.rs
@@ -398,6 +398,7 @@ impl Core {
     }
 
     async fn handle_tc(&mut self, tc: TC) -> ConsensusResult<()> {
+        tc.verify(&self.committee)?;
         if tc.round < self.round {
             return Ok(());
         }


### PR DESCRIPTION
Fix issue #77 
The node was not checking the TCs and instead blindly trusted them. This is very strange since the function `handle_tc` returns a `ConsensusResult<()>` that was never used :/